### PR TITLE
Fix pip install failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.111.*
+fastapi>=0.111,<0.112
 uvicorn[standard]
 sqlalchemy>=2.0,<3
 pydantic[email]


### PR DESCRIPTION
## Summary
- correct FastAPI version spec in `requirements.txt`

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6887cb4a8f7483318649c1283b5a44b6