### PR TITLE
Fix BaseSettings import

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 
 from functools import lru_cache
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://user:password@localhost/vet_db"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.111.*
+fastapi>=0.111,<0.112
 uvicorn[standard]
 sqlalchemy>=2.0,<3
 pydantic[email]


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic_settings` for Pydantic v2 compatibility

## Testing
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_6887cb4a8f7483318649c1283b5a44b6