### PR TITLE
Fix 500 errors by switching to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ It now includes CRUD APIs for:
 * Prescriptions and patient histories
 * Payments and orders
 
-The codebase comes with a configuration stub, a DB session dependency and a ready‑to‑install `requirements.txt`.
+The codebase comes with a configuration stub, a DB session dependency and a ready‑to‑install `requirements.txt`. It defaults to an embedded SQLite database so you can try the API without running Postgres.
+
+Run the following once to create the SQLite tables:
+
+```bash
+python app/create_db.py
+```
 
 ## Quick start
 

--- a/app/config.py
+++ b/app/config.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
-    database_url: str = "postgresql+asyncpg://user:password@localhost/vet_db"
+    database_url: str = "sqlite+aiosqlite:///./vet_db.sqlite3"
     secret_key: str = "change-me"
 
     class Config:

--- a/app/create_db.py
+++ b/app/create_db.py
@@ -1,0 +1,12 @@
+import asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from app.config import get_settings
+from app.models import Base
+
+async def init_models():
+    engine = create_async_engine(get_settings().database_url, echo=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+if __name__ == "__main__":
+    asyncio.run(init_models())

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,31 @@
 
+import uuid
+from sqlalchemy.types import TypeDecorator, CHAR
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import DeclarativeBase
+
+
+class GUID(TypeDecorator):
+    """Platform-independent GUID/UUID type."""
+
+    impl = CHAR
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(postgresql.UUID(as_uuid=True))
+        return dialect.type_descriptor(CHAR(36))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        return str(uuid.UUID(value))
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        return uuid.UUID(str(value))
 
 class Base(DeclarativeBase):
     pass

--- a/app/models/employee.py
+++ b/app/models/employee.py
@@ -1,12 +1,11 @@
 import uuid
 from sqlalchemy import String, Date, Column
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class Employee(Base):
     __tablename__ = "employees"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
     name = Column(String(128), nullable=False)
     role = Column(String(64), nullable=False)
     hire_date = Column(Date)

--- a/app/models/equipment.py
+++ b/app/models/equipment.py
@@ -1,12 +1,11 @@
 import uuid
 from sqlalchemy import String, Date, Column
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class Equipment(Base):
     __tablename__ = "equipment"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
     name = Column(String(128), nullable=False)
     purchase_date = Column(Date)
     status = Column(String(64))

--- a/app/models/inventory_item.py
+++ b/app/models/inventory_item.py
@@ -1,12 +1,11 @@
 import uuid
 from sqlalchemy import String, Integer, Float, Column
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class InventoryItem(Base):
     __tablename__ = "inventory_items"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
     name = Column(String(128), nullable=False)
     description = Column(String(256))
     quantity = Column(Integer, default=0)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,13 +1,12 @@
 import uuid
 from sqlalchemy import String, Integer, Float, Column, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class Order(Base):
     __tablename__ = "orders"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    patient_id = Column(UUID(as_uuid=True), ForeignKey("patients.id"), nullable=False)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
+    patient_id = Column(GUID(), ForeignKey("patients.id"), nullable=False)
     item_name = Column(String(128), nullable=False)
     quantity = Column(Integer, default=1)
     price = Column(Float, default=0.0)

--- a/app/models/patient.py
+++ b/app/models/patient.py
@@ -1,13 +1,12 @@
 
 import uuid
 from sqlalchemy import String, Date, Column
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class Patient(Base):
     __tablename__ = "patients"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
     name = Column(String(128), nullable=False)
     species = Column(String(64), nullable=False)
     breed = Column(String(128))

--- a/app/models/patient_history.py
+++ b/app/models/patient_history.py
@@ -1,12 +1,11 @@
 import uuid
 from sqlalchemy import String, Date, Column, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class PatientHistory(Base):
     __tablename__ = "patient_histories"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    patient_id = Column(UUID(as_uuid=True), ForeignKey("patients.id"), nullable=False)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
+    patient_id = Column(GUID(), ForeignKey("patients.id"), nullable=False)
     visit_date = Column(Date)
     notes = Column(String(256))

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,13 +1,12 @@
 import uuid
 from sqlalchemy import String, Date, Float, Column, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class Payment(Base):
     __tablename__ = "payments"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    patient_id = Column(UUID(as_uuid=True), ForeignKey("patients.id"), nullable=False)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
+    patient_id = Column(GUID(), ForeignKey("patients.id"), nullable=False)
     amount = Column(Float, nullable=False)
     paid_on = Column(Date)
     method = Column(String(64))

--- a/app/models/prescription.py
+++ b/app/models/prescription.py
@@ -1,13 +1,12 @@
 import uuid
 from sqlalchemy import String, Column, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
-from app.models import Base
+from app.models import Base, GUID
 
 class Prescription(Base):
     __tablename__ = "prescriptions"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    patient_id = Column(UUID(as_uuid=True), ForeignKey("patients.id"), nullable=False)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
+    patient_id = Column(GUID(), ForeignKey("patients.id"), nullable=False)
     medication = Column(String(128), nullable=False)
     dosage = Column(String(64))
     instructions = Column(String(256))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ sqlalchemy>=2.0,<3
 pydantic[email]
 pydantic-settings>=2.1
 asyncpg
+aiosqlite
 python-multipart
 passlib[bcrypt]


### PR DESCRIPTION
## Summary
- add a platform independent GUID type and update models
- default configuration uses SQLite
- add script to create DB tables
- document SQLite default and init step in README
- include aiosqlite in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887d064b0848331ac9051942ac10d8e